### PR TITLE
fix: numpy required before setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, Extension
-try:
-    from numpy import get_include
-except ImportError:
-    raise RuntimeError("NumPy is required to build the C extension in FlowUtils")
+
+class get_numpy_include(object):
+    def __str__(self):
+        import numpy
+        return numpy.get_include()
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -13,7 +14,7 @@ logicle_extension = Extension(
         'flowutils/logicle_c_ext/_logicle.c',
         'flowutils/logicle_c_ext/logicle.c'
     ],
-    include_dirs=[get_include(), 'flowutils/logicle_c_ext'],
+    include_dirs=[get_numpy_include(), 'flowutils/logicle_c_ext'],
     extra_compile_args=['-std=c99']
 )
 
@@ -31,6 +32,7 @@ setup(
     url="https://github.com/whitews/flowutils",
     ext_modules=[logicle_extension],
     install_requires=['numpy>=1.7'],
+    setup_requires=['numpy>=1.7'],
     classifiers=[
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Requiring any dependencies before calling setuptools should always be avoided.

Please also look into releasing wheels. The sdist/setup.py installation method is from ancient times. It doesn't have a proper standard for metadata and executes code from within the package during installation. This is undesirable for any modern package management scenarios.