### PR TITLE
Make FlowUtils (and Flowkit) compatible with NumPy >= 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ['setuptools>=61.0', 'oldest-supported-numpy']
+requires = ['setuptools>=61.0', 'numpy>=2']
 build-backend   = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ if __version__ is None:
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+
 logicle_extension = Extension(
     'flowutils.logicle_c',
     sources=[
@@ -22,7 +23,7 @@ logicle_extension = Extension(
         'src/flowutils/logicle_c_ext/logicle.c'
     ],
     include_dirs=[np.get_include(), 'src/flowutils/logicle_c_ext'],
-    extra_compile_args=['-std=c99']
+    extra_compile_args=['-std=c99', '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
 )
 
 gating_extension = Extension(
@@ -32,7 +33,7 @@ gating_extension = Extension(
         'src/flowutils/gating_c_ext/gate_helpers.c'
     ],
     include_dirs=[np.get_include(), 'src/flowutils/gating_c_ext'],
-    extra_compile_args=['-std=c99']
+    extra_compile_args=['-std=c99', '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION']
 )
 
 setup(
@@ -49,7 +50,7 @@ setup(
     license='BSD',
     url="https://github.com/whitews/flowutils",
     ext_modules=[logicle_extension, gating_extension],
-    install_requires=['numpy>=1.20,<2'],
+    install_requires=['numpy>=2.0,<3.0'],
     classifiers=[
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.11',

--- a/src/flowutils/gating_c_ext/gate_helpers.c
+++ b/src/flowutils/gating_c_ext/gate_helpers.c
@@ -70,7 +70,7 @@ int * points_in_polygon(int *wind_counts, double *poly_vertices, int vert_count,
 
     This implementation is based on the C implementation here:
 
-        http://geomalgorithms.com/a03-_inclusion.html
+        http://geomalgorithms.com/a03-_inclusion.html % This website seems to be a scam now ?
 
     Original copyright notice:
         Copyright 2000 softSurfer, 2012 Dan Sunday

--- a/src/flowutils/logicle_c_ext/_logicle.c
+++ b/src/flowutils/logicle_c_ext/_logicle.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION // to avoid a warning
 #include <numpy/arrayobject.h>
 #include "logicle.h"
 
@@ -11,12 +12,10 @@ static PyObject *wrap_logicle_scale(PyObject *self, PyObject *args) {
         return NULL;
     }
 
-    // read the numpy array
-    PyObject *x_array = PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_IN_ARRAY);
-
+    PyArrayObject *x_array = (PyArrayObject *) PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
     // throw exception if the array doesn't exist
-    if (x_array == NULL) {
-        Py_XDECREF(x_array);
+    if (!x_array) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to convert x to NumPy array");
         return NULL;
     }
 
@@ -29,7 +28,7 @@ static PyObject *wrap_logicle_scale(PyObject *self, PyObject *args) {
     // now we can call our function!
     logicle_scale(t, w, m, a, xc, n);
 
-    return x_array;
+    return (PyObject *) x_array;
 }
 
 static PyObject *wrap_logicle_inverse(PyObject *self, PyObject *args) {
@@ -42,11 +41,9 @@ static PyObject *wrap_logicle_inverse(PyObject *self, PyObject *args) {
     }
 
     // read the numpy array
-    PyObject *x_array = PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_IN_ARRAY);
-
-    // throw exception if the array doesn't exist
-    if (x_array == NULL) {
-        Py_XDECREF(x_array);
+    PyArrayObject *x_array = (PyArrayObject *) PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (!x_array) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to convert x to NumPy array");
         return NULL;
     }
 
@@ -59,7 +56,7 @@ static PyObject *wrap_logicle_inverse(PyObject *self, PyObject *args) {
     // now we can call our function!
     logicle_inverse(t, w, m, a, xc, n);
 
-    return x_array;
+    return (PyObject *) x_array;
 }
 
 static PyObject *wrap_hyperlog_scale(PyObject *self, PyObject *args) {
@@ -72,11 +69,9 @@ static PyObject *wrap_hyperlog_scale(PyObject *self, PyObject *args) {
     }
 
     // read the numpy array
-    PyObject *x_array = PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_IN_ARRAY);
-
-    // throw exception if the array doesn't exist
-    if (x_array == NULL) {
-        Py_XDECREF(x_array);
+    PyArrayObject *x_array = (PyArrayObject *) PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (!x_array) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to convert x to NumPy array");
         return NULL;
     }
 
@@ -89,7 +84,7 @@ static PyObject *wrap_hyperlog_scale(PyObject *self, PyObject *args) {
     // now we can call our function!
     hyperlog_scale(t, w, m, a, xc, n);
 
-    return x_array;
+    return (PyObject *) x_array;
 }
 
 static PyObject *wrap_hyperlog_inverse(PyObject *self, PyObject *args) {
@@ -102,11 +97,9 @@ static PyObject *wrap_hyperlog_inverse(PyObject *self, PyObject *args) {
     }
 
     // read the numpy array
-    PyObject *x_array = PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_IN_ARRAY);
-
-    // throw exception if the array doesn't exist
-    if (x_array == NULL) {
-        Py_XDECREF(x_array);
+    PyArrayObject *x_array = (PyArrayObject *) PyArray_FROM_OTF(x, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
+    if (!x_array) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to convert x to NumPy array");
         return NULL;
     }
 
@@ -119,7 +112,7 @@ static PyObject *wrap_hyperlog_inverse(PyObject *self, PyObject *args) {
     // now we can call our function!
     hyperlog_inverse(t, w, m, a, xc, n);
 
-    return x_array;
+    return (PyObject *) x_array;
 }
 
 
@@ -133,29 +126,41 @@ static PyMethodDef module_methods[] = {
 
 #if PY_MAJOR_VERSION >= 3
 static struct PyModuleDef logicledef = {
-        PyModuleDef_HEAD_INIT,
-        "logicle_c",
-        NULL,
-        -1,
-        module_methods
+    PyModuleDef_HEAD_INIT,
+    "logicle_c",
+    NULL,
+    -1,
+    module_methods
 };
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 PyMODINIT_FUNC PyInit_logicle_c(void) {
     PyObject *m = PyModule_Create(&logicledef);
-#else
-PyMODINIT_FUNC initlogicle_c(void) {
-    PyObject *m = Py_InitModule3("logicle_c", module_methods, NULL);
-#endif
-
     if (m == NULL) {
         return NULL;
     }
 
-    import_array();
+    import_array(); 
+    if (PyErr_Occurred()) {  
+        Py_DECREF(m);
+        return NULL;
+    }
 
-#if PY_MAJOR_VERSION >= 3
     return m;
-#endif
 }
+#else
+PyMODINIT_FUNC initlogicle_c(void) {
+    PyObject *m = Py_InitModule3("logicle_c", module_methods, NULL);
+    if (m == NULL) {
+        return;
+    }
+
+    import_array();  
+    if (PyErr_Occurred()) {
+        Py_DECREF(m);
+        return;
+    }
+
+    return;
+}
+#endif
+


### PR DESCRIPTION
Hi,
FlowUtils (and therefore Flowkit) are blocked to (at best) numpy=1.26 because of the [change in its C API](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide). This PR updates the package to ensure compatibility with NumPy version 2.0 and above.

**What changes have been made?**.

In both __logicle.c_ and _gate_helpers.c_ :
- Replaced outdated _NPY_IN_ARRAY_ with _NPY_ARRAY_IN_ARRAY_
- Use _PyArrayObject_ instead of _PyObject_ when calling C functions like _PyArray_DATA_
- Change the way we throw exception if the array doesn't exist

In the setup files:
- Set the minimum NumPy version to 2.0 in pyproject.toml and setup.py.
- Add the tag -_DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION_ in the _extra_compile_args_
-> This new version must be **compiled with numpy>=2.x**, but the python can be used with older versions of numpy (at least 1.26 works for me).

**Breaking changes**
    The package now requires NumPy >= 2.0 to compile the C files. Older versions are no longer supported.
    
 **How was this tested?**
I use **run_test.py**, no changes where made in the unit tests.

**Bonus**
In _gate_helpers.c_ you mention that the algorithm you use for _points_in_polygon_ is based on a website. But this website now seems to be a scam.
 
